### PR TITLE
Fixed default Icon not working for Popups

### DIFF
--- a/PySimpleGUI.py
+++ b/PySimpleGUI.py
@@ -3418,7 +3418,7 @@ class Window:
         self.Font = font if font else DEFAULT_FONT
         self.RadioDict = {}
         self.BorderDepth = border_depth
-        self.WindowIcon = icon if icon is not None else Window.user_defined_icon
+        self.WindowIcon = Window.user_defined_icon if Window.user_defined_icon is not None else icon if icon is not None else DEFAULT_WINDOW_ICON
         self.AutoClose = auto_close
         self.NonBlocking = False
         self.TKroot = None


### PR DESCRIPTION
When setting an icon via SetOptions(icon=file), the main window uses that icon, but Popups and sub windows won't unless they're called with icon=None argument.
This propagates the user_defined_icon as default icon, unless otherwise specified.