### PR TITLE
Fix missing GetText() method for Text class

### DIFF
--- a/PySimpleGUI.py
+++ b/PySimpleGUI.py
@@ -1214,6 +1214,9 @@ class Text(Element):
         elif visible is True:
             self.TKText.pack()
 
+    def GetText(self):
+        return self.DisplayText
+
     def __del__(self):
         super().__del__()
 


### PR DESCRIPTION
I read the documentation and it states that I should call `GetText()` on a gui element of type `Text` to receive the current `DisplayText` value. This didn't work, so I took a look at the source and found this function was not implemented. It's just a simple fix to work according to the docs.

If you prefer to get the value by calling `.DisplayText`, take this as a notice that the docs are outdated. ;)

Thanks for your great work btw.