### PR TITLE
Add a .__version__ global to PySimpleGUI.py

### DIFF
--- a/PySimpleGUI.py
+++ b/PySimpleGUI.py
@@ -35,6 +35,8 @@ from random import randint
 #             d8888P                          dP
 
 
+__version__ = '3.29.0'
+
 g_time_start = 0
 g_time_end = 0
 g_time_delta = 0


### PR DESCRIPTION
`.__version__` globals are added most Python modules to enable functionality such as:
```
$ python -c "import PySimpleGUI ; print(PySimpleGUI.__version__)"
3.29.0
```

Other examples:
```
$ python -c "import chess ; print(chess.__version__)"
0.27.3
$ python -c "import requests ; print(requests.__version__)"
2.21.0
$ python -c "import pip ; print(pip.__version__)"
19.1
$ python -c "import flake8 ; print(flake8.__version__)"
3.7.7
```