### PR TITLE
Demo_OpenCV.py use cv.imencode instead of PIL

### DIFF
--- a/DemoPrograms/Demo_OpenCV.py
+++ b/DemoPrograms/Demo_OpenCV.py
@@ -48,7 +48,7 @@ def main():
         window.FindElement('slider').Update(i)
         i += 1
 
-        imgbytes = cv2.imencode('.png', frame)[1].tobytes()  # ditto
+        imgbytes = cv.imencode('.png', frame)[1].tobytes()  # ditto
         window.FindElement('image').Update(data=imgbytes)
 
 

--- a/DemoPrograms/Demo_OpenCV.py
+++ b/DemoPrograms/Demo_OpenCV.py
@@ -5,8 +5,6 @@ if sys.version_info[0] >= 3:
 else:
     import PySimpleGUI27 as sg
 import cv2 as cv
-from PIL import Image
-import io
 from sys import exit as exit
 
 """
@@ -50,11 +48,7 @@ def main():
         window.FindElement('slider').Update(i)
         i += 1
 
-        # let img be the PIL image
-        img = Image.fromarray(frame)  # create PIL image from frame
-        bio = io.BytesIO()  # a binary memory resident stream
-        img.save(bio, format= 'PNG')  # save image as png to it
-        imgbytes = bio.getvalue()  # this can be used by OpenCV hopefully
+        imgbytes = cv2.imencode('.png', frame)[1].tobytes()  # ditto
         window.FindElement('image').Update(data=imgbytes)
 
 


### PR DESCRIPTION
Use `cv2.imencode('.png', frame)`  (as the other OpenCV examples do) instead of conversion via PIL.

This example is the most popular and the one which pops up when searching for PySimpleGUI and OpenCV.  The detour via PIL is an unnecessary performance hit.

Warning: I made this edit online via github; thus this is not tested in ANY way!