### PR TITLE
Fix memory leak due to Images of Graph

### DIFF
--- a/PySimpleGUI.py
+++ b/PySimpleGUI.py
@@ -2029,7 +2029,7 @@ class Graph(Element):
         self.DragSubmits = drag_submits
         self.ClickPosition = (None, None)
         self.MouseButtonDown = False
-        self.Images = []
+        self.Images = {}
         self.RightClickMenu = right_click_menu
 
         super().__init__(ELEM_TYPE_GRAPH, background_color=background_color, size=canvas_size, pad=pad, key=key,
@@ -2184,9 +2184,9 @@ class Graph(Element):
             print('*** WARNING - The Graph element has not been finalized and cannot be drawn upon ***')
             print('Call Window.Finalize() prior to this operation')
             return None
-        self.Images.append(image)
         try:  # in case closed with X
             id = self._TKCanvas2.create_image(converted_point, image=image, anchor=tk.NW)
+            self.Images[id] = image
         except:
             id = None
         return id
@@ -2198,6 +2198,7 @@ class Graph(Element):
             print('*** WARNING - The Graph element has not been finalized and cannot be drawn upon ***')
             print('Call Window.Finalize() prior to this operation')
             return None
+        self.Images = {}
         try:            # in case window was closed with X
             self._TKCanvas2.delete('all')
         except:
@@ -2206,6 +2207,7 @@ class Graph(Element):
 
     def DeleteFigure(self, id):
         try:
+            del self.Images[id]
             self._TKCanvas2.delete(id)
         except:
             print('DeleteFigure - bad ID {}'.format(id))

--- a/PySimpleGUI27.py
+++ b/PySimpleGUI27.py
@@ -2031,7 +2031,7 @@ class Graph(Element):
         self.DragSubmits = drag_submits
         self.ClickPosition = (None, None)
         self.MouseButtonDown = False
-        self.Images = []
+        self.Images = {}
         self.RightClickMenu = right_click_menu
 
         super().__init__(ELEM_TYPE_GRAPH, background_color=background_color, size=canvas_size, pad=pad, key=key,
@@ -2186,9 +2186,9 @@ class Graph(Element):
             print('*** WARNING - The Graph element has not been finalized and cannot be drawn upon ***')
             print('Call Window.Finalize() prior to this operation')
             return None
-        self.Images.append(image)
         try:  # in case closed with X
             id = self._TKCanvas2.create_image(converted_point, image=image, anchor=tk.NW)
+            self.Images[id] = image
         except:
             id = None
         return id
@@ -2200,6 +2200,7 @@ class Graph(Element):
             print('*** WARNING - The Graph element has not been finalized and cannot be drawn upon ***')
             print('Call Window.Finalize() prior to this operation')
             return None
+        self.Images = {}
         try:            # in case window was closed with X
             self._TKCanvas2.delete('all')
         except:
@@ -2208,6 +2209,7 @@ class Graph(Element):
 
     def DeleteFigure(self, id):
         try:
+            del self.Images[id]
             self._TKCanvas2.delete(id)
         except:
             print('DeleteFigure - bad ID {}'.format(id))


### PR DESCRIPTION
 - `Graph` used a list `self.Images` to which new images where appended on
   `DrawImage`.  Neither in `DeleteFigure` nor in `Erase` were any elements
   removed from that list.  Thus any added image was kept in memory as
   long as the corresponding `Graph` was; even if it wasn't used
   anymore.

 - Even though `self.Images` is not referred to in any other way,
   removing the list completely does not work; the result
   is that no images are drawn on the `Graph`.

 - The implemented solution uses a dictionary (id -> image) to keep
   only used images in `self.Images`.  Images are added in `DrawImage` and removed (by id) in `DeleteFigure` and (all) in `Erase`

I tested the changes with some of my local programs (making heavy use of images in Graphs).