### PR TITLE
Fix Radio button update

### DIFF
--- a/PySimpleGUI.py
+++ b/PySimpleGUI.py
@@ -900,10 +900,10 @@ class Radio(Element):
                          tooltip=tooltip, visible=visible)
 
     def Update(self, value=None, disabled=None, visible=None):
-        location = EncodeRadioRowCol(self.ParentForm.ContainerElemementNumber, self.Position[0], self.Position[1])
         if value is not None:
             try:
-                self.TKIntVar.set(location)
+                self.TKIntVar.set(self.EncodedRadioValue)
+                self.InitialState = value
             except:
                 pass
             self.InitialState = value

--- a/PySimpleGUI27.py
+++ b/PySimpleGUI27.py
@@ -917,10 +917,10 @@ class Radio(Element):
                          tooltip=tooltip, visible=visible)
 
     def Update(self, value=None, disabled=None, visible=None):
-        location = EncodeRadioRowCol(self.ParentForm.ContainerElemementNumber, self.Position[0], self.Position[1])
         if value is not None:
             try:
-                self.TKIntVar.set(location)
+                self.TKIntVar.set(self.EncodedRadioValue)
+                self.InitialState = value
             except:
                 pass
             self.InitialState = value


### PR DESCRIPTION
Class Radio tries to compute EncodedRadioValue and fails.
But PackFormIntoFrame() already fills class self.EncodedRadioValue with the right value.

This fixes non working ```window.Element('myRadioButton').Update(True)```

