### PR TITLE
Update PySimpleGUIQt.py

### DIFF
--- a/PySimpleGUIQt/PySimpleGUIQt.py
+++ b/PySimpleGUIQt/PySimpleGUIQt.py
@@ -3845,6 +3845,10 @@ def create_style_from_font(font):
     if font is None:
         return ''
 
+    # Allows user to specify just underlining and keeping default (Helvetica) text and size (10) by just typing 'underline' or ('', '', 'underline') in the font argument
+    if font == 'underline' or font == ('', '', 'underline'):
+        return "font-family: Helvetica;\nfont-size: 10;\ntext-decoration: underline;"
+    
     if type(font) is str:
         _font = font.split(' ')
     else:


### PR DESCRIPTION
Updated functionality allowing the user to just specify 'underline' in the font argument if they want to keep the default font and font size.  As it stands, if you change the font argument to ("", "" ,"underline") or "   underline" it will return Arial font instead of the default Helvetica used by the rest of the default fonts.