### PR TITLE
Typo in help-file corrected: SetToolTip --> SetTooltip

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11086,7 +11086,7 @@ Parameter Descriptions:
 
 ### set_tooltip
 
-Called by application to change the tooltip text for an Element.  Normally invoked using the Element Object such as: window.Element('key').SetToolTip('New tip').
+Called by application to change the tooltip text for an Element.  Normally invoked using the Element Object such as: window.Element('key').SetTooltip('New tip').
 
 ```
 set_tooltip(tooltip_text)


### PR DESCRIPTION
In help file heading and code example are correct, but description had lowercase/uppercase typo:
`such as: window.Element("key").SetToolTip("New tip")` 