### PR TITLE
Use bold instead of headings for callouts

### DIFF
--- a/docs/call reference.md
+++ b/docs/call reference.md
@@ -4,13 +4,13 @@
 
 Here you will find the details for all Elements, Objects, and Functions that are available to you.  If you want to use a complex element and don't understand the parameters, then this is the right place to come.  For every element you're shown the parameters used to create it as well as all methods available to call.
 
-## Currently PySimpleGUI (tkinter) only
+**Currently PySimpleGUI (tkinter) only**
 
 This documentation is created using the PySimpleGUI.py file which means it's based on the tkinter code. Some of the calls are different, might not exist at all, or there may be more methods/functions for the other PySimpleGUI ports (Qt, Wx, Web).  
 
 Work is underway to get the PySimpleGUIQt docstrings completed and corrected.
 
-## Caution - Some functions / methods may be internal only yet exposed in this documentation
+**Caution - Some functions / methods may be internal only yet exposed in this documentation**
 
 This section of the documentation is generated directly from the source code.  As a result, sometimes internal only functions or methods that you are not supposed to be calling are accidently shown in this documentation.  Hopefully these accidents don't happen often.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,12 +19,11 @@
 
 # PySimpleGUI User's Manual
 
-## Python GUI For Humans - Transforms tkinter, Qt, Remi, WxPython into portable people-friendly Pythonic interfaces
+Python GUI For Humans - Transforms tkinter, Qt, Remi, WxPython into portable people-friendly Pythonic interfaces
 
-## <span>The Call Reference Section Moved to <a href="https://pysimplegui.readthedocs.io/en/latest/call%20reference/">here</a></span>
+**The [Call Reference Section](https://pysimplegui.readthedocs.io/en/latest/call%20reference/) has moved.**
 
-### This manual is crammed full of answers so start your search for answers here. Read/Search this prior to opening an Issue on GitHub.  Press Control F and type.
----
+**This manual is crammed full of answers so start your search for answers here. Read/Search this prior to opening an Issue on GitHub.  Press Control F and type.**
 
 # Jump-Start
 

--- a/readme_creator/markdown input files/1_HEADER_top_part.md
+++ b/readme_creator/markdown input files/1_HEADER_top_part.md
@@ -48,13 +48,11 @@ HOW DO I INSERT IMAGES ???
 
 # PySimpleGUI User's Manual
 
+Python GUI For Humans - Transforms tkinter, Qt, Remi, WxPython into portable people-friendly Pythonic interfaces
 
-## Python GUI For Humans - Transforms tkinter, Qt, Remi, WxPython into portable people-friendly Pythonic interfaces
+**The [Call Reference Section](https://pysimplegui.readthedocs.io/en/latest/call%20reference/) has moved.**
 
-## <span>The Call Reference Section Moved to <a href="https://pysimplegui.readthedocs.io/en/latest/call%20reference/">here</a></span>
-
-### This manual is crammed full of answers so start your search for answers here. Read/Search this prior to opening an Issue on GitHub.  Press Control F and type.
----
+**This manual is crammed full of answers so start your search for answers here. Read/Search this prior to opening an Issue on GitHub.  Press Control F and type.**
 
 # Jump-Start
 

--- a/readme_creator/markdown input files/5_call_reference.md
+++ b/readme_creator/markdown input files/5_call_reference.md
@@ -4,13 +4,13 @@
 
 Here you will find the details for all Elements, Objects, and Functions that are available to you.  If you want to use a complex element and don't understand the parameters, then this is the right place to come.  For every element you're shown the parameters used to create it as well as all methods available to call.
 
-## Currently PySimpleGUI (tkinter) only
+**Currently PySimpleGUI (tkinter) only**
 
 This documentation is created using the PySimpleGUI.py file which means it's based on the tkinter code. Some of the calls are different, might not exist at all, or there may be more methods/functions for the other PySimpleGUI ports (Qt, Wx, Web).  
 
 Work is underway to get the PySimpleGUIQt docstrings completed and corrected.
 
-## Caution - Some functions / methods may be internal only yet exposed in this documentation
+**Caution - Some functions / methods may be internal only yet exposed in this documentation**
 
 This section of the documentation is generated directly from the source code.  As a result, sometimes internal only functions or methods that you are not supposed to be calling are accidently shown in this documentation.  Hopefully these accidents don't happen often.
 


### PR DESCRIPTION
This change adjusts a couple of headings in the documentation to use bold instead of heading styles. This should improve the usability of the TOC in the generated documentation.