### PR TITLE
Fix typo in readme.ja.md

### DIFF
--- a/readme.ja.md
+++ b/readme.ja.md
@@ -160,7 +160,7 @@ layout = [[sg.Text("お名前は何ですか？")],
           [sg.Button('はい'), sg.Button('終了')]]
 
 # ウィンドウを作成する
-window = sg.Window('ウィンドウタイトル',レイアウト)
+window = sg.Window('ウィンドウタイトル',layout)
 
 # イベントループを使用してウィンドウを表示し、対話する
 while True:


### PR DESCRIPTION
Fixed a problem with the sample code.
The variable name in the sample code was translated incorrectly.

readme.jaに含まれるサンプルコードの間違いを修正しました。
コード内のサンプルコードの変数名を修正しました。