### PR TITLE
mistype fix

### DIFF
--- a/DemoPrograms/Demo_Compact_Layouts_Element_Renaming.py
+++ b/DemoPrograms/Demo_Compact_Layouts_Element_Renaming.py
@@ -41,7 +41,7 @@ B = sg.B
 layout = [[M(size=(30, 3))],
           [B('OK')]]
 
-window = sg.Window('Shortcuts', layout).read()
+window = sg.Window('Shortcuts', layout)
 event, values = window.read()
 sg.popup_scrolled(event, values)
 window.close()


### PR DESCRIPTION
in Demo: Compact Layouts Element Renaming (double invocation to read() method leads to a runtime error, as the second call is on tuple, not of window class).