### PR TITLE
Fix the mis-translation of the code part.

### DIFF
--- a/docs/readme Japanese Version.md
+++ b/docs/readme Japanese Version.md
@@ -160,7 +160,7 @@ layout = [[sg.Text("お名前は何ですか？")],
           [sg.Button('はい'), sg.Button('終了')]]
 
 # ウィンドウを作成する
-window = sg.Window('ウィンドウタイトル',レイアウト)
+window = sg.Window('ウィンドウタイトル',layout)
 
 # イベントループを使用してウィンドウを表示し、対話する
 while True:


### PR DESCRIPTION
日本語ドキュメント内のコード中において変数名(`layout`)が突然`レイアウト`に変わっています。
これが原因で`レイアウト`を`layout`に直さなければチュートリアルのコードが動作しないため修正しました。(修正すると正常に動作することを確認しました。)

修正前の日本語のドキュメント
![2021-03-25 20 17 02 github com 149f50f3cb9d](https://user-images.githubusercontent.com/11572238/112464648-1b2e3500-8da7-11eb-8ff8-834bf77a04da.jpg)

英語版のドキュメント
![2021-03-25 20 18 38 github com 37ebe5b5a04c](https://user-images.githubusercontent.com/11572238/112464827-52044b00-8da7-11eb-81a0-a773a541fc37.jpg)

I found mis-translate in Japanese document's.
English variable name is suddenly translated into Japanese in the middle of the sample code and the code doesn't work now.
I fix the mis-translation.