### PR TITLE
Fix bad spacing and punctuation in example output

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -141,7 +141,7 @@ window = sg.Window('Window Title', layout)      # Part 3 - Window Defintion
 event, values = window.read()                   # Part 4 - Event loop or Window.read call
 
 # Do something with the information gathered
-print('Hello', values[0], "! Thanks for trying PySimpleGUI")
+print('Hello {}! Thanks for trying PySimpleGUI.'.format(values[0]))
 
 # Finish up by removing from the screen
 window.close()                                  # Part 5 - Close the Window


### PR DESCRIPTION
Current output:
```
Hello Bob ! Thanks for trying PySimpleGUI
```

Fixed output:
```
Hello Bob! Thanks for trying PySimpleGUI.
```