### PR TITLE
Use Object oriented matplotlib in toolbar demo

### DIFF
--- a/DemoPrograms/Demo_Matplotlib_Embedded_Toolbar.py
+++ b/DemoPrograms/Demo_Matplotlib_Embedded_Toolbar.py
@@ -7,34 +7,16 @@ import numpy as np
 """
 
 # ------------------------------- This is to include a matplotlib figure in a Tkinter canvas
-import matplotlib.pyplot as plt
+from matplotlib.figure import Figure
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
 
-
-def draw_figure_w_toolbar(canvas, fig, canvas_toolbar):
-    if canvas.children:
-        for child in canvas.winfo_children():
-            child.destroy()
-    if canvas_toolbar.children:
-        for child in canvas_toolbar.winfo_children():
-            child.destroy()
-    figure_canvas_agg = FigureCanvasTkAgg(fig, master=canvas)
-    figure_canvas_agg.draw()
-    toolbar = Toolbar(figure_canvas_agg, canvas_toolbar)
-    toolbar.update()
-    figure_canvas_agg.get_tk_widget().pack(side='right', fill='both', expand=1)
-
-
-class Toolbar(NavigationToolbar2Tk):
-    def __init__(self, *args, **kwargs):
-        super(Toolbar, self).__init__(*args, **kwargs)
 
 
 # ------------------------------- PySimpleGUI CODE
 
 layout = [
     [sg.T('Graph: y=sin(x)')],
-    [sg.B('Plot'), sg.B('Exit')],
+    [sg.B('Randomize Plot'), sg.B('Exit')],
     [sg.T('Controls:')],
     [sg.Canvas(key='controls_cv')],
     [sg.T('Figure:')],
@@ -54,28 +36,43 @@ layout = [
 
 window = sg.Window('Graph with controls', layout)
 
+# apply the layout so that the canvas exists for matplotlib to use.
+window.finalize()
+
+# Set up the Matplotlib Figure
+DPI = 100
+fig = Figure((404 * 2 / float(DPI), 404 / float(DPI)), dpi=DPI)
+canvas = FigureCanvasTkAgg(fig, master=window["fig_cv"].TKCanvas)  # A tk.DrawingArea.
+
+toolbar = NavigationToolbar2Tk(canvas, window["controls_cv"].TKCanvas)
+toolbar.update()
+fig.set_size_inches(404 * 2 / float(DPI), 404 / float(DPI))
+canvas.draw()
+canvas.get_tk_widget().pack(side="right", fill="both", expand=1)
+
+# Set up matplotlib styling
+# This won't change each loop
+ax = fig.gca()
+ax.set_title("y=sin(1 * x)")
+ax.set_xlabel("X")
+ax.set_ylabel("Y")
+ax.grid(True)
+
+# create initial line element
+x = np.linspace(0, 2 * np.pi)
+y = np.sin(x)
+line = ax.plot(x, y)[0]
+
 while True:
     event, values = window.read()
     print(event, values)
     if event in (sg.WIN_CLOSED, 'Exit'):  # always,  always give a way out!
         break
-    elif event is 'Plot':
+    elif event == "Randomize Plot":
         # ------------------------------- PASTE YOUR MATPLOTLIB CODE HERE
-        plt.figure(1)
-        fig = plt.gcf()
-        DPI = fig.get_dpi()
-        # ------------------------------- you have to play with this size to reduce the movement error when the mouse hovers over the figure, it's close to canvas size
-        fig.set_size_inches(404 * 2 / float(DPI), 404 / float(DPI))
-        # -------------------------------
-        x = np.linspace(0, 2 * np.pi)
-        y = np.sin(x)
-        plt.plot(x, y)
-        plt.title('y=sin(x)')
-        plt.xlabel('X')
-        plt.ylabel('Y')
-        plt.grid()
-
-        # ------------------------------- Instead of plt.show()
-        draw_figure_w_toolbar(window['fig_cv'].TKCanvas, fig, window['controls_cv'].TKCanvas)
+        tau = np.random.randn()
+        line.set_ydata(np.sin(x * tau))
+        ax.set_title(f"y=sin({tau:.2f} * x)")
+        fig.canvas.draw_idle()
 
 window.close()


### PR DESCRIPTION
This is the preferred way over using pyplot
when embedding matplotlib into a GUI. This avoids using the pyplot
global state to keep track of things and also should have performance
gains by no longer needing to continually destroy and create
matplotlib canvases.

I also made what was formerly the `plot` event always update the graphed
line so that users can see that their actions are taking an effect.