### PR TITLE
Removed the recently added test for Mac so that the SECOND of the wm_…

### DIFF
--- a/PySimpleGUI.py
+++ b/PySimpleGUI.py
@@ -14523,9 +14523,8 @@ def _convert_window_to_tk(window):
     window.TKroot.y = int(y)
     window.starting_window_position = (int(x), (int(y)))
     master.update_idletasks()  # don't forget
-    # The Mac is sensative to notitlebar, so skipping the second call
-    if not running_mac():
-        _no_titlebar_setup(window)
+
+    _no_titlebar_setup(window)
 
     return
 
@@ -14614,8 +14613,7 @@ def StartupTK(window):
     window.SetIcon(window.WindowIcon)
 
     try:
-        root.attributes('-alpha',
-                        1 if window.AlphaChannel is None else window.AlphaChannel)  # Make window visible again
+        root.attributes('-alpha', 1 if window.AlphaChannel is None else window.AlphaChannel)  # Make window visible again
     except:
         pass
 


### PR DESCRIPTION
…overriderediects is restored like it was last week.