### PR TITLE
FIX: convert_tkinter_filetypes_to_wx: missing pipe

### DIFF
--- a/PySimpleGUIWx/PySimpleGUIWx.py
+++ b/PySimpleGUIWx/PySimpleGUIWx.py
@@ -1496,11 +1496,13 @@ class Button(Element):
 
 
 def convert_tkinter_filetypes_to_wx(filetypes):
-    wx_filetypes = ''
+    wx_filetypes = []
     for item in filetypes:
         filetype = item[0] + ' (' + item[1] + ')|'+ item[1]
-        wx_filetypes += filetype
-    return wx_filetypes
+        wx_filetypes.append(filetype)
+
+    wx_filetype_string = "|".join(wx_filetypes)
+    return wx_filetype_string
 
 
 # -------------------------  Button lazy functions  ------------------------- #


### PR DESCRIPTION
convert_tkinter_filetypes_to_wx(filetypes) (1498) simply concatenates formated filetypes which leads to an omitted pipe between each filetype (e.g. "JPG (*.jpg)|*.jpgall file (*.*)|*.*") causing missing pipe error (for two elements) or resulting in weird drop down entries otherwise.

FIX: append formated filetype strings to a list and then join the list elements to final string using pipe ("|")