### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5606,7 +5606,7 @@ Be a good computing citizen.  Run with a non-zero timeout so that other programs
 
 ### Small Timeout Values (under 10ms)
 
-***Do Not*** use a timeout of less than 10ms.  Otherwise you will simply thrash, spending your time trying to do some GUI stuff, only to be interruped by a timeout timer before it can get anything done.  The results are potentially disasterous.
+***Do Not*** use a timeout of less than 10ms.  Otherwise you will simply thrash, spending your time trying to do some GUI stuff, only to be interrupted by a timeout timer before it can get anything done.  The results are potentially disasterous.
 
 There is a hybrid approach... a read with a timeout.   You'll score much higher points on the impressive meter if you're able to use a lot less CPU time by using this type of read.
 
@@ -6534,7 +6534,7 @@ This tab is provided to you as a way to interact with your running program on a 
 
 If you want to quickly look at the values of variables, nearly ANY variables, then type the information into one of the 3 spaces provided to "Watch" either variables or experessions.  In this example, the variable window was typed into the first slow.
 
-***Immediately*** after typing the character 'w', the information to the right was displayed.  No button needs to be clicked.  You merely neeed to type in a valid experession and it will be displayed to you.... and it will be displayed on an on-going, constantly-refreshing-basis.
+***Immediately*** after typing the character 'w', the information to the right was displayed.  No button needs to be clicked.  You merely need to type in a valid experession and it will be displayed to you.... and it will be displayed on an on-going, constantly-refreshing-basis.
 
 ![SNAG-0447](https://user-images.githubusercontent.com/13696193/62797393-a0b58200-baa9-11e9-8016-1cadca4d97e7.jpg)
 

--- a/readme_creator/markdown input files/2_readme.md
+++ b/readme_creator/markdown input files/2_readme.md
@@ -3997,7 +3997,7 @@ Be a good computing citizen.  Run with a non-zero timeout so that other programs
 
 ### Small Timeout Values (under 10ms)
 
-***Do Not*** use a timeout of less than 10ms.  Otherwise you will simply thrash, spending your time trying to do some GUI stuff, only to be interruped by a timeout timer before it can get anything done.  The results are potentially disasterous.
+***Do Not*** use a timeout of less than 10ms.  Otherwise you will simply thrash, spending your time trying to do some GUI stuff, only to be interrupted by a timeout timer before it can get anything done.  The results are potentially disasterous.
 
 
 
@@ -4973,7 +4973,7 @@ This tab is provided to you as a way to interact with your running program on a 
 
 If you want to quickly look at the values of variables, nearly ANY variables, then type the information into one of the 3 spaces provided to "Watch" either variables or experessions.  In this example, the variable window was typed into the first slow.
 
-***Immediately*** after typing the character 'w', the information to the right was displayed.  No button needs to be clicked.  You merely neeed to type in a valid experession and it will be displayed to you.... and it will be displayed on an on-going, constantly-refreshing-basis.
+***Immediately*** after typing the character 'w', the information to the right was displayed.  No button needs to be clicked.  You merely need to type in a valid experession and it will be displayed to you.... and it will be displayed on an on-going, constantly-refreshing-basis.
 
 ![SNAG-0447](https://user-images.githubusercontent.com/13696193/62797393-a0b58200-baa9-11e9-8016-1cadca4d97e7.jpg)
 

--- a/readme_creator/output/index.md
+++ b/readme_creator/output/index.md
@@ -5606,7 +5606,7 @@ Be a good computing citizen.  Run with a non-zero timeout so that other programs
 
 ### Small Timeout Values (under 10ms)
 
-***Do Not*** use a timeout of less than 10ms.  Otherwise you will simply thrash, spending your time trying to do some GUI stuff, only to be interruped by a timeout timer before it can get anything done.  The results are potentially disasterous.
+***Do Not*** use a timeout of less than 10ms.  Otherwise you will simply thrash, spending your time trying to do some GUI stuff, only to be interrupted by a timeout timer before it can get anything done.  The results are potentially disasterous.
 
 There is a hybrid approach... a read with a timeout.   You'll score much higher points on the impressive meter if you're able to use a lot less CPU time by using this type of read.
 
@@ -6534,7 +6534,7 @@ This tab is provided to you as a way to interact with your running program on a 
 
 If you want to quickly look at the values of variables, nearly ANY variables, then type the information into one of the 3 spaces provided to "Watch" either variables or experessions.  In this example, the variable window was typed into the first slow.
 
-***Immediately*** after typing the character 'w', the information to the right was displayed.  No button needs to be clicked.  You merely neeed to type in a valid experession and it will be displayed to you.... and it will be displayed on an on-going, constantly-refreshing-basis.
+***Immediately*** after typing the character 'w', the information to the right was displayed.  No button needs to be clicked.  You merely need to type in a valid experession and it will be displayed to you.... and it will be displayed on an on-going, constantly-refreshing-basis.
 
 ![SNAG-0447](https://user-images.githubusercontent.com/13696193/62797393-a0b58200-baa9-11e9-8016-1cadca4d97e7.jpg)
 


### PR DESCRIPTION
There are small typos in:
- docs/index.md
- readme_creator/markdown input files/2_readme.md
- readme_creator/output/index.md

Fixes:
- Should read `need` rather than `neeed`.
- Should read `interrupted` rather than `interruped`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md