### PR TITLE
Use pyscreenshot as a fallback to PIL.ImageGrab

### DIFF
--- a/PySimpleGUI.py
+++ b/PySimpleGUI.py
@@ -12072,11 +12072,14 @@ class Window:
         if not pil_import_attempted:
             try:
                 import PIL as PIL
-                from PIL import ImageGrab
+                try:
+                    from PIL import ImageGrab
+                except ImportError:
+                    import pyscreenshot as ImageGrab
                 from PIL import Image
                 pil_imported = True
                 pil_import_attempted = True
-            except:
+            except ImportError:
                 pil_imported = False
                 pil_import_attempted = True
                 print('FAILED TO IMPORT PIL!')


### PR DESCRIPTION
Image Grab from PIL is only usable with window and Mac. As pyscreenshot is the alternative to ImageGrab for Linux we could import this library as a fallback in save_window_screenshot_to_disk.