### PR TITLE
Use ==/!= to compare constant literals (str, bytes, int, float, tuple)

### DIFF
--- a/DemoPrograms/Demo_Matplotlib_Embedded_Toolbar.py
+++ b/DemoPrograms/Demo_Matplotlib_Embedded_Toolbar.py
@@ -59,7 +59,7 @@ while True:
     print(event, values)
     if event in (sg.WIN_CLOSED, 'Exit'):  # always,  always give a way out!
         break
-    elif event is 'Plot':
+    elif event == 'Plot':
         # ------------------------------- PASTE YOUR MATPLOTLIB CODE HERE
         plt.figure(1)
         fig = plt.gcf()

--- a/PySimpleGUIWeb/PySimpleGUIWeb.py
+++ b/PySimpleGUIWeb/PySimpleGUIWeb.py
@@ -1358,13 +1358,13 @@ class Button(Element):
         if image_data:
             self.Widget.empty()
             simage = SuperImage(image_data)
-            if image_size is not (None, None):
+            if image_size != (None, None):
                 simage.set_size(image_size[0], image_size[1])
             self.Widget.append(simage)
         if image_filename:
             self.Widget.empty()
             simage = SuperImage(image_filename)
-            if image_size is not (None, None):
+            if image_size != (None, None):
                 simage.set_size(image_size[0], image_size[1])
             self.Widget.append(simage)
 


### PR DESCRIPTION
Equality is not the same thing as identity in Python.
Flake8 F632 use ==/!= to compare constant literals (str, bytes, int, float, tuple)

% `python3.11`
```
>>> event = 'Plo'
>>> event += 't'
>>> event == 'Plot'
True
>>> event is 'Plot'
<stdin>:1: SyntaxWarning: "is" with a literal. Did you mean "=="?
False
```
