### PR TITLE
Updated text color for combobox when background color set

### DIFF
--- a/PySimpleGUI.py
+++ b/PySimpleGUI.py
@@ -2741,7 +2741,7 @@ class Combo(Element):
             combostyle.map(style_name, fieldforeground=[('readonly', text_color)])
             self.TextColor = text_color
         if background_color is not None:
-            combostyle.configure(style_name, selectforeground=background_color)
+            combostyle.configure(style_name, selectforeground=text_color)
             combostyle.map(style_name, fieldbackground=[('readonly', background_color)])
             combostyle.configure(style_name, fieldbackground=background_color)
             self.BackgroundColor = background_color

--- a/PySimpleGUI.py
+++ b/PySimpleGUI.py
@@ -395,6 +395,8 @@ _change_log = """
         Checkbox - added highlight thickness parm to control how thick the focus ring is. Defaults to 1 still but now changable
     4.61.0.164
         Input element - fixed problem where the input 'cursor' (the I-beam) was being set to the THEME'S color, not the color indicated by the individual element
+    4.61.0.165
+        Changed color of text in combobox, when background color set, to be different from background color
     """
 
 __version__ = version.split()[0]  # For PEP 396 and PEP 345


### PR DESCRIPTION
The text color for a combobox would be the same as the background color, if the combobox had a background color set. This would make the text invisible.