### PR TITLE
Visualization of the codebase

### DIFF
--- a/.codeboarding/Demo_Program_Browser.md
+++ b/.codeboarding/Demo_Program_Browser.md
@@ -1,0 +1,219 @@
+```mermaid
+
+graph LR
+
+    DemoBrowserApplication["DemoBrowserApplication"]
+
+    GUIBuilder["GUIBuilder"]
+
+    EventProcessor["EventProcessor"]
+
+    FileManagement["FileManagement"]
+
+    UserSettingsManager["UserSettingsManager"]
+
+    SearchAndFilter["SearchAndFilter"]
+
+    ProgramExecutor["ProgramExecutor"]
+
+    ExternalToolLauncher["ExternalToolLauncher"]
+
+    DemoBrowserApplication -- "initializes" --> GUIBuilder
+
+    DemoBrowserApplication -- "processes events via" --> EventProcessor
+
+    DemoBrowserApplication -- "utilizes" --> FileManagement
+
+    DemoBrowserApplication -- "manages settings with" --> UserSettingsManager
+
+    GUIBuilder -- "provides layout to" --> DemoBrowserApplication
+
+    EventProcessor -- "receives events from" --> DemoBrowserApplication
+
+    EventProcessor -- "triggers" --> SearchAndFilter
+
+    EventProcessor -- "triggers" --> ProgramExecutor
+
+    EventProcessor -- "triggers" --> ExternalToolLauncher
+
+    FileManagement -- "provides data to" --> DemoBrowserApplication
+
+    FileManagement -- "provides data to" --> SearchAndFilter
+
+    UserSettingsManager -- "provides settings to" --> DemoBrowserApplication
+
+    UserSettingsManager -- "provides settings to" --> ExternalToolLauncher
+
+    SearchAndFilter -- "queries" --> FileManagement
+
+    SearchAndFilter -- "provides filtered results to" --> DemoBrowserApplication
+
+    ProgramExecutor -- "triggered by" --> EventProcessor
+
+    ExternalToolLauncher -- "triggered by" --> EventProcessor
+
+    ExternalToolLauncher -- "uses" --> UserSettingsManager
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+One paragraph explaining the functionality which is represented by this graph. What the main flow is and what is its purpose.
+
+
+
+### DemoBrowserApplication
+
+This is the core orchestrator of the Demo Program Browser. It is responsible for initializing the main GUI window, managing the application's event loop, and coordinating interactions between all other components. It acts as the central hub for the user's interaction with the demo programs, including receiving filtered data for UI updates. It's fundamental because it defines the application's lifecycle and overall flow.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/PySimpleGUI/PySimpleGUI/blob/master/DemoPrograms/Browser_START_HERE_Demo_Programs_Browser.py#L1-L1" target="_blank" rel="noopener noreferrer">`DemoPrograms/Browser_START_HERE_Demo_Programs_Browser.py` (1:1)</a>
+
+
+
+
+
+### GUIBuilder
+
+This component is dedicated to constructing the visual layout of the Demo Program Browser's main window. It defines and arranges all PySimpleGUI elements, such as listboxes for demo files, input fields for search and filter, buttons for actions (Run, Edit, Settings), and status indicators. It's fundamental as it provides the user interface, making the application interactive and usable.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/PySimpleGUI/PySimpleGUI/blob/master/DemoPrograms/Browser_START_HERE_Demo_Programs_Browser.py#L1-L1" target="_blank" rel="noopener noreferrer">`DemoPrograms/Browser_START_HERE_Demo_Programs_Browser.py` (1:1)</a>
+
+
+
+
+
+### EventProcessor
+
+This component is responsible for capturing and interpreting user interactions (events) within the Demo Program Browser's GUI. It reads events from the PySimpleGUI window and dispatches them to the appropriate handlers or components for further processing. It's fundamental because it enables the application to respond to user input, driving all interactive features.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/PySimpleGUI/PySimpleGUI/blob/master/DemoPrograms/Browser_START_HERE_Demo_Programs_Browser.py#L1-L1" target="_blank" rel="noopener noreferrer">`DemoPrograms/Browser_START_HERE_Demo_Programs_Browser.py` (1:1)</a>
+
+
+
+
+
+### FileManagement
+
+This component handles all operations related to discovering, listing, and providing access to the demo program files within the specified directory. It manages the logic for retrieving file names and their full paths, including handling duplicate file names. It's fundamental as the application's core purpose is to browse these files.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/PySimpleGUI/PySimpleGUI/blob/master/DemoPrograms/Browser_START_HERE_Demo_Programs_Browser.py#L1-L1" target="_blank" rel="noopener noreferrer">`DemoPrograms/Browser_START_HERE_Demo_Programs_Browser.py` (1:1)</a>
+
+
+
+
+
+### UserSettingsManager
+
+This component is responsible for managing the application's configuration and user preferences. It handles loading and saving settings such as the default demo folder, the path to the external editor, and the "advanced mode" setting, ensuring persistence across sessions. It's fundamental for user customization and maintaining application state.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/PySimpleGUI/PySimpleGUI/blob/master/DemoPrograms/Browser_START_HERE_Demo_Programs_Browser.py#L1-L1" target="_blank" rel="noopener noreferrer">`DemoPrograms/Browser_START_HERE_Demo_Programs_Browser.py` (1:1)</a>
+
+
+
+
+
+### SearchAndFilter
+
+This component provides the functionality to narrow down the list of demo programs. It supports filtering by filename and performing content-based searches within the source code of the demo files, utilizing regular expressions for advanced searches. After processing, it provides the filtered results to the `DemoBrowserApplication` for display. It's fundamental for efficient navigation and discovery within a large set of demo programs.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/PySimpleGUI/PySimpleGUI/blob/master/DemoPrograms/Browser_START_HERE_Demo_Programs_Browser.py#L1-L1" target="_blank" rel="noopener noreferrer">`DemoPrograms/Browser_START_HERE_Demo_Programs_Browser.py` (1:1)</a>
+
+
+
+
+
+### ProgramExecutor
+
+This component is responsible for executing the selected demo program. When a user chooses to run a demo, this component initiates the execution of the corresponding Python script, typically by invoking system commands. It's fundamental as it enables users to directly interact with and see the demos in action.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/PySimpleGUI/PySimpleGUI/blob/master/DemoPrograms/Browser_START_HERE_Demo_Programs_Browser.py#L1-L1" target="_blank" rel="noopener noreferrer">`DemoPrograms/Browser_START_HERE_Demo_Programs_Browser.py` (1:1)</a>
+
+
+
+
+
+### ExternalToolLauncher
+
+This component facilitates opening the selected demo program in an external text editor or revealing its location in the system's file explorer. It leverages the editor and explorer paths configured in the user settings. It's fundamental for allowing users to inspect and modify the demo source code or manage the files directly.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/PySimpleGUI/PySimpleGUI/blob/master/DemoPrograms/Browser_START_HERE_Demo_Programs_Browser.py#L1-L1" target="_blank" rel="noopener noreferrer">`DemoPrograms/Browser_START_HERE_Demo_Programs_Browser.py` (1:1)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/External_Tool_Launcher.md
+++ b/.codeboarding/External_Tool_Launcher.md
@@ -1,0 +1,183 @@
+```mermaid
+
+graph LR
+
+    External_Tool_Launcher["External Tool Launcher"]
+
+    UserSettingsManager["UserSettingsManager"]
+
+    OSInteraction["OSInteraction"]
+
+    PySimpleGUI["PySimpleGUI"]
+
+    OSModule["OSModule"]
+
+    SubprocessModule["SubprocessModule"]
+
+    Demo_Program_Browser_Client_["Demo Program Browser (Client)"]
+
+    Demo_Program_Browser_Client_ -- "requests launch from" --> External_Tool_Launcher
+
+    External_Tool_Launcher -- "requests paths from" --> UserSettingsManager
+
+    External_Tool_Launcher -- "initiates execution via" --> OSInteraction
+
+    UserSettingsManager -- "accesses settings in" --> PySimpleGUI
+
+    OSInteraction -- "utilizes" --> OSModule
+
+    OSInteraction -- "utilizes" --> SubprocessModule
+
+    click External_Tool_Launcher href "https://github.com/PySimpleGUI/PySimpleGUI/blob/master/.codeboarding//External_Tool_Launcher.md" "Details"
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+One paragraph explaining the functionality which is represented by this graph. What the main flow is and what is its purpose.
+
+
+
+### External Tool Launcher
+
+This component orchestrates the process of launching external applications, such as text editors for source files or file explorers for directories. It acts as an intermediary, retrieving the configured paths for these tools and then initiating their execution.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/PySimpleGUI/PySimpleGUI/blob/master/DemoPrograms/psgdemos.py#L1-L1" target="_blank" rel="noopener noreferrer">`DemoPrograms/psgdemos.py` (1:1)</a>
+
+- <a href="https://github.com/PySimpleGUI/PySimpleGUI/blob/master/DemoPrograms/Browser_START_HERE_Demo_Programs_Browser.py#L1-L1" target="_blank" rel="noopener noreferrer">`DemoPrograms/Browser_START_HERE_Demo_Programs_Browser.py` (1:1)</a>
+
+
+
+
+
+### UserSettingsManager
+
+Responsible for retrieving user-defined settings, specifically the file paths for the preferred external text editor and file explorer. It interacts with the `PySimpleGUI` library's user settings mechanism to fetch these configurations.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/PySimpleGUI/PySimpleGUI/blob/master/DemoPrograms/psgdemos.py#L1-L1" target="_blank" rel="noopener noreferrer">`DemoPrograms/psgdemos.py:get_editor` (1:1)</a>
+
+- <a href="https://github.com/PySimpleGUI/PySimpleGUI/blob/master/DemoPrograms/psgdemos.py#L1-L1" target="_blank" rel="noopener noreferrer">`DemoPrograms/psgdemos.py:get_explorer` (1:1)</a>
+
+
+
+
+
+### OSInteraction
+
+This component provides a low-level interface for interacting with the operating system. It encapsulates the actual calls to system commands or functions (like `os.startfile` or `subprocess.run`) required to launch external applications or open directories.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `os` (1:1)
+
+- `subprocess` (1:1)
+
+
+
+
+
+### PySimpleGUI
+
+The underlying GUI library that provides the framework for the application's user interface. It also offers mechanisms for managing and persisting user settings, which are crucial for the `UserSettingsManager` to retrieve tool paths.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `PySimpleGUI` (1:1)
+
+
+
+
+
+### OSModule
+
+Python's standard library module that provides a portable way of using operating system-dependent functionality. In this context, it's used by `OSInteraction` for functions like `os.startfile` to open files or directories using their default associated applications.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `os` (1:1)
+
+
+
+
+
+### SubprocessModule
+
+Python's standard library module for spawning new processes, connecting to their input/output/error pipes, and obtaining their return codes. It's used by `OSInteraction` for more controlled execution of external programs, especially when specific arguments or environment settings are needed.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `subprocess` (1:1)
+
+
+
+
+
+### Demo Program Browser (Client)
+
+This is the main application component that initiates requests to open demo program source files in an external editor or to open the directory containing a demo program in the system's file explorer. It acts as the user-facing interface that triggers the external tool launching process.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/PySimpleGUI/PySimpleGUI/blob/master/DemoPrograms/Browser_START_HERE_Demo_Programs_Browser.py#L1-L1" target="_blank" rel="noopener noreferrer">`DemoPrograms/Browser_START_HERE_Demo_Programs_Browser.py` (1:1)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/User_Settings_Manager.md
+++ b/.codeboarding/User_Settings_Manager.md
@@ -1,0 +1,109 @@
+```mermaid
+
+graph LR
+
+    User_Settings_Manager["User Settings Manager"]
+
+    PySimpleGUI_Core["PySimpleGUI Core"]
+
+    Application_Controller["Application Controller"]
+
+    External_Program_Launcher["External Program Launcher"]
+
+    User_Settings_Manager -- "uses" --> PySimpleGUI_Core
+
+    Application_Controller -- "uses" --> User_Settings_Manager
+
+    External_Program_Launcher -- "relies on" --> User_Settings_Manager
+
+    click User_Settings_Manager href "https://github.com/PySimpleGUI/PySimpleGUI/blob/master/.codeboarding//User_Settings_Manager.md" "Details"
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+The User Settings Manager is fundamental because it centralizes all logic related to user preferences, ensuring that the application's behavior is tailored to individual user choices. By abstracting the direct calls to PySimpleGUI's settings API, it makes the rest of the application cleaner and more focused on its core tasks, rather than on the specifics of settings persistence. This separation of concerns allows for easy modification of how settings are stored or retrieved without impacting other components. Its role in providing consistent access to user-defined paths for external tools (editor, explorer) and application modes (advanced mode) is crucial for the overall user experience and functionality of the Demo Program Browser.
+
+
+
+### User Settings Manager
+
+This component is dedicated to managing the persistence and retrieval of user-specific configurations and preferences for the Demo Program Browser. It provides a unified interface for accessing settings such as the preferred demo folder, the path to an external text editor, the file explorer, and display options like "advanced mode." It intelligently prioritizes user-defined settings over global PySimpleGUI defaults when applicable, abstracting the direct interaction with PySimpleGUI's underlying user settings storage mechanism.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/PySimpleGUI/PySimpleGUI/blob/master/DemoPrograms/psgdemos.py#L0-L0" target="_blank" rel="noopener noreferrer">`psgdemos.get_demo_path` (0:0)</a>
+
+- <a href="https://github.com/PySimpleGUI/PySimpleGUI/blob/master/DemoPrograms/psgdemos.py#L0-L0" target="_blank" rel="noopener noreferrer">`psgdemos.get_global_editor` (0:0)</a>
+
+- <a href="https://github.com/PySimpleGUI/PySimpleGUI/blob/master/DemoPrograms/psgdemos.py#L0-L0" target="_blank" rel="noopener noreferrer">`psgdemos.get_editor` (0:0)</a>
+
+- <a href="https://github.com/PySimpleGUI/PySimpleGUI/blob/master/DemoPrograms/psgdemos.py#L0-L0" target="_blank" rel="noopener noreferrer">`psgdemos.using_local_editor` (0:0)</a>
+
+- <a href="https://github.com/PySimpleGUI/PySimpleGUI/blob/master/DemoPrograms/psgdemos.py#L0-L0" target="_blank" rel="noopener noreferrer">`psgdemos.get_explorer` (0:0)</a>
+
+- <a href="https://github.com/PySimpleGUI/PySimpleGUI/blob/master/DemoPrograms/psgdemos.py#L0-L0" target="_blank" rel="noopener noreferrer">`psgdemos.advanced_mode` (0:0)</a>
+
+- `sg.user_settings_get_entry` (0:0)
+
+- `sg.pysimplegui_user_settings.get` (0:0)
+
+- `sg.user_settings_set_entry` (0:0)
+
+
+
+
+
+### PySimpleGUI Core
+
+Provides core functionalities and APIs for PySimpleGUI applications, including user settings management.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### Application Controller
+
+Manages the overall application flow, GUI initialization, file operations, and user interactions.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### External Program Launcher
+
+Responsible for launching external programs like text editors or file explorers based on user configurations.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/on_boarding.md
+++ b/.codeboarding/on_boarding.md
@@ -1,0 +1,135 @@
+```mermaid
+
+graph LR
+
+    Demo_Program_Browser["Demo Program Browser"]
+
+    Demo_Programs_Collection["Demo Programs Collection"]
+
+    User_Settings_Manager["User Settings Manager"]
+
+    External_Tool_Launcher["External Tool Launcher"]
+
+    Demo_Program_Browser -- "Manages" --> Demo_Programs_Collection
+
+    Demo_Program_Browser -- "Utilizes" --> User_Settings_Manager
+
+    Demo_Program_Browser -- "Integrates with" --> External_Tool_Launcher
+
+    Demo_Programs_Collection -- "Executed by" --> Demo_Program_Browser
+
+    User_Settings_Manager -- "Configures" --> Demo_Program_Browser
+
+    User_Settings_Manager -- "Influences" --> External_Tool_Launcher
+
+    External_Tool_Launcher -- "Used by" --> Demo_Program_Browser
+
+    External_Tool_Launcher -- "Configured by" --> User_Settings_Manager
+
+    click Demo_Program_Browser href "https://github.com/PySimpleGUI/PySimpleGUI/blob/master/.codeboarding//Demo_Program_Browser.md" "Details"
+
+    click User_Settings_Manager href "https://github.com/PySimpleGUI/PySimpleGUI/blob/master/.codeboarding//User_Settings_Manager.md" "Details"
+
+    click External_Tool_Launcher href "https://github.com/PySimpleGUI/PySimpleGUI/blob/master/.codeboarding//External_Tool_Launcher.md" "Details"
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+The analysis of the file structure reveals that the current repository is primarily focused on DemoPrograms for PySimpleGUI, rather than the core PySimpleGUI library itself. This means the PySimpleGUI Library and Underlying GUI Frameworks are external dependencies to this project. Based on this understanding and the provided abstract components, the critical interaction pathways and central modules within this demo project are centered around the Demo Program Browser and its management of the Demo Programs. The PySimpleGUI Library and Underlying GUI Frameworks were excluded as primary components of this project because the file structure indicates they are external dependencies, not part of the source code managed within this specific repository. While crucial for the functionality of the demos, they are not developed or maintained within this project's scope. 'File System Utilities' was absorbed into 'System Interaction Utilities' (renamed to 'External Tool Launcher' for clarity) and the 'Demo Program Browser' itself, as its functions are primarily in support of these higher-level interactions.
+
+
+
+### Demo Program Browser
+
+This is the central application of the repository. It provides a graphical user interface for users to browse, filter, search, run, and edit the various PySimpleGUI demo programs. It acts as the primary entry point for exploring the library's capabilities through its examples.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/PySimpleGUI/PySimpleGUI/blob/master/DemoPrograms/Browser_START_HERE_Demo_Programs_Browser.py#L-1-L-1" target="_blank" rel="noopener noreferrer">`Browser_START_HERE_Demo_Programs_Browser.py` (-1:-1)</a>
+
+- <a href="https://github.com/PySimpleGUI/PySimpleGUI/blob/master/DemoPrograms/psgdemos.py#L-1-L-1" target="_blank" rel="noopener noreferrer">`psgdemos.py` (-1:-1)</a>
+
+
+
+
+
+### Demo Programs Collection
+
+This component represents the extensive set of individual Python scripts, each designed to showcase a specific feature, element, or design pattern of the PySimpleGUI library. These are the executable examples that demonstrate the library's functionality.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/PySimpleGUI/PySimpleGUI/blob/master/DemoPrograms/Demo_All_Elements.py#L-1-L-1" target="_blank" rel="noopener noreferrer">`Demo_All_Elements.py` (-1:-1)</a>
+
+- <a href="https://github.com/PySimpleGUI/PySimpleGUI/blob/master/DemoPrograms/Demo_Hello_World.py#L-1-L-1" target="_blank" rel="noopener noreferrer">`Demo_Hello_World.py` (-1:-1)</a>
+
+- <a href="https://github.com/PySimpleGUI/PySimpleGUI/blob/master/DemoPrograms/Demo_Matplotlib_Embedded_TEMPLATE.py#L-1-L-1" target="_blank" rel="noopener noreferrer">`Demo_Matplotlib_Embedded_TEMPLATE.py` (-1:-1)</a>
+
+
+
+
+
+### User Settings Manager
+
+This component is responsible for handling the persistence of user-specific configurations and preferences for the Demo Program Browser. This includes saving and loading settings such as the preferred demo folder, the path to an external text editor, and other display options.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/PySimpleGUI/PySimpleGUI/blob/master/DemoPrograms/Browser_START_HERE_Demo_Programs_Browser.py#L-1-L-1" target="_blank" rel="noopener noreferrer">`Browser_START_HERE_Demo_Programs_Browser.py` (-1:-1)</a>
+
+- <a href="https://github.com/PySimpleGUI/PySimpleGUI/blob/master/DemoPrograms/psgdemos.py#L-1-L-1" target="_blank" rel="noopener noreferrer">`psgdemos.py` (-1:-1)</a>
+
+
+
+
+
+### External Tool Launcher
+
+This component provides the functionality to interact with the operating system by launching external applications. Specifically, it enables the Demo Program Browser to open demo program source files in a user-defined external text editor or to open the directory containing a demo program in the system's file explorer.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/PySimpleGUI/PySimpleGUI/blob/master/DemoPrograms/Browser_START_HERE_Demo_Programs_Browser.py#L-1-L-1" target="_blank" rel="noopener noreferrer">`Browser_START_HERE_Demo_Programs_Browser.py` (-1:-1)</a>
+
+- <a href="https://github.com/PySimpleGUI/PySimpleGUI/blob/master/DemoPrograms/psgdemos.py#L-1-L-1" target="_blank" rel="noopener noreferrer">`psgdemos.py` (-1:-1)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)


### PR DESCRIPTION
With this PR, I intorduce diagrams representation for the PySimpleGUI project to help new contributors orient themselves in the codebase.
You can see how the proposed changes render here:
https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/PySimpleGUI/on_boarding.md

PySimpleGUI has nearly 2k forks -> many developers are exploring the codebase—likely focusing on specific components. That’s why we think that diagram-first documentation can help - with it users can quickly locate the part they care about and understand how it fits into the larger system. What’s your take on this approach?

I'd usually open a discussion first, but you don't have them enabled for this repo so I decided to go ahead and open a PR.

Any feedback is more than welcome!

Full transparency: we’re exploring this idea as a potential startup, but we’re still early and figuring out what’s actually useful to developers.